### PR TITLE
Remove a whole bunch of waits at end of round

### DIFF
--- a/mapscripts/braundorf_b4.script
+++ b/mapscripts/braundorf_b4.script
@@ -102,7 +102,7 @@ game_manager
 	trigger endgame
 	{
 		
-   		wait 500
+   		//wait 500 // remove wait because comp
    		
 		wm_objective_status 2 1 1
 		wm_objective_status 2 0 2

--- a/mapscripts/et_beach.script
+++ b/mapscripts/et_beach.script
@@ -304,7 +304,7 @@ game_manager
 		wm_teamvoiceannounce 1 "objective_allies_secured"
 
 		//mortis reduce silly wait state from 1500 to 50
-		wait 50
+		//wait 50 // remove completely because why not
 		// End the round
 		wm_endround
 	}

--- a/mapscripts/et_ufo_final.script
+++ b/mapscripts/et_ufo_final.script
@@ -186,7 +186,7 @@ allied_obj4
 		wm_objective_status 4 1 1
 
 		wm_announce	"Allies Transmitted the UFO Documents!"
-		wait 1500
+		//wait 1500 // remove wait because comp
 
 		wm_setwinner 1
 

--- a/mapscripts/etl_adlernest_v2.script
+++ b/mapscripts/etl_adlernest_v2.script
@@ -97,7 +97,7 @@ documents
 		remapshader "models/mapobjects/tanks_sd/bits_r"							"models/mapobjects/tanks_sd/bits_r"	
 		remapshaderflush
 		
-		wait 100
+		//wait 100 // remove wait because comp
 		wm_endround
 	}
 }

--- a/mapscripts/etl_ice_v8.script
+++ b/mapscripts/etl_ice_v8.script
@@ -70,7 +70,7 @@ game_manager
 		wm_objective_status 		1 0 1
 		wm_objective_status 		1 1 2
 
-		wait 1500
+		//wait 1500 // remove wait because comp
 		wm_endround
 	}
 }

--- a/mapscripts/karsiah_te2.script
+++ b/mapscripts/karsiah_te2.script
@@ -222,7 +222,7 @@ game_manager
 		wm_objective_status 5 1 1
 
 		wm_setwinner 1
-		wait 1000
+		//wait 1000 // remove wait because comp
 		wm_endround
 	}
 }

--- a/mapscripts/te_escape2.script
+++ b/mapscripts/te_escape2.script
@@ -124,7 +124,7 @@ secret_exit
 		wm_teamvoiceannounce 1 "allies_hq_objective_captured"
 
 		wm_setwinner 1
-		wait 500
+		//wait 500 // no wait at end because comp
 		wm_endround 
 	}
 }


### PR DESCRIPTION
Some maps still had waits in them, while others have had them removed completely (see e.g. frostbite.script, adlernest.script, sw_goldrush_te.script). Left etl_supply_v6.script unchanged because don't wanna mess with sounds.