### PR TITLE
Maxpackets and rate fixed value, Karsiash mapscript fixed by Aciz

### DIFF
--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -146,8 +146,8 @@ init
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate IN 25000 45000"
-	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar rate EQ 45000"
+	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -146,8 +146,8 @@ init
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate IN 25000 45000"
-	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar rate EQ 45000"
+	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 

--- a/configs/legacy5.config
+++ b/configs/legacy5.config
@@ -146,8 +146,8 @@ init
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate IN 25000 45000"
-	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar rate EQ 45000"
+	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -146,8 +146,8 @@ init
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate IN 25000 45000"
-	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar rate EQ 45000"
+	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 

--- a/mapscripts/Karsiah_te2.script
+++ b/mapscripts/Karsiah_te2.script
@@ -7,7 +7,7 @@ game_manager
 			scriptname "doornwall"
 			targetname "doornwall"
 			classname "func_door_rotating"
-			allowteams "1"
+			allowteams "axis"
 			origin "976 -1684 331"
 			type "4"
 			model "*14"
@@ -222,7 +222,7 @@ game_manager
 		wm_objective_status 5 1 1
 
 		wm_setwinner 1
-		wait 1000
+		//wait 1000 // remove wait because comp
 		wm_endround
 	}
 }

--- a/mapscripts/karsiah_te2.script
+++ b/mapscripts/karsiah_te2.script
@@ -7,7 +7,7 @@ game_manager
 			scriptname "doornwall"
 			targetname "doornwall"
 			classname "func_door_rotating"
-			allowteams "1"
+			allowteams "axis"
 			origin "976 -1684 331"
 			type "4"
 			model "*14"


### PR DESCRIPTION
According to feedback from the community, most people play already with rate 45000 and maxpackets 125, NA and OCE included, so no reason to allow lower maxpackets or rates (even though the maximum rate is not getting reached in comp)

The door was bugged on Karsiah, Aciz fixed it.