### PR TITLE
Save/Load for practise config

### DIFF
--- a/configs/practice.config
+++ b/configs/practice.config
@@ -123,7 +123,7 @@ init
 	setl g_pronedelay "1"
 
 	// set this to disable wolfadmin or enable custom Lua files
-	//setl lua_modules ""
+	setl lua_modules "saveload.lua"
 
 	set g_log "practice.log"
 

--- a/saveload.lua
+++ b/saveload.lua
@@ -19,8 +19,11 @@ function savePosition(clientNum)
 	playerSprints[clientNum] = sprint
 end
 
--- will print error to console if target hasn't saved yet, but won't crash
 function loadPosition(clientNum)
+	if playerPositions[clientNum] == nil then
+		return
+	end
+
 	pos = playerPositions[clientNum]
 	et.gentity_set(clientNum, "ps.origin", playerPositions[clientNum])
 
@@ -42,8 +45,10 @@ end
 function et_ClientCommand(clientNum, command)
 	if command == "save" then
 		savePosition(clientNum)
+		return 1
 	end
 	if command == "load" then
 		loadPosition(clientNum)
+		return 1
 	end
 end

--- a/saveload.lua
+++ b/saveload.lua
@@ -1,0 +1,49 @@
+-- simple save/load mod tested on Legacy
+-- saves position on /save
+-- restores position on /load
+-- resets speed to 0
+-- saves and loads amount of stamina
+
+-- hazz
+-- Feb 2023
+
+local modname = "SaveLoad"
+local version = 1.0
+local playerPositions = {}
+local playerSprints = {}
+
+function savePosition(clientNum)
+	pos = et.gentity_get(clientNum, "ps.origin")
+	playerPositions[clientNum] = pos
+	sprint = et.gentity_get(clientNum, "ps.stats", et.STAT_SPRINTTIME)
+	playerSprints[clientNum] = sprint
+end
+
+-- will print error to console if target hasn't saved yet, but won't crash
+function loadPosition(clientNum)
+	pos = playerPositions[clientNum]
+	et.gentity_set(clientNum, "ps.origin", playerPositions[clientNum])
+
+	-- reset speed so you don't have to load more than once
+	et.gentity_set(clientNum, "ps.velocity", {0, 0, 0})
+
+	-- restore sprint to what it was when saved
+	-- could also load with full sprint, but
+	-- sometimes you wanna try jumps with a certain amount of sprint
+	sprint = playerSprints[clientNum]
+	et.gentity_set(clientNum, "ps.stats", et.STAT_SPRINTTIME, sprint)
+end
+
+-- callbacks
+function et_InitGame(levelTime, randomSeed, restart)
+	et.RegisterModname(modname .. version .. " " .. et.FindSelf())
+end
+
+function et_ClientCommand(clientNum, command)
+	if command == "save" then
+		savePosition(clientNum)
+	end
+	if command == "load" then
+		loadPosition(clientNum)
+	end
+end


### PR DESCRIPTION
Can be useful for practicing trickjumps and such on match servers.

Load sets speed to 0 and restores stamina to the level the player had when loading.