### PR TITLE
Fix mapscript not loading if players callvote map mApNAMe

### DIFF
--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -128,7 +128,7 @@ init
 	setl g_pronedelay "1"
 
 	// set this to disable wolfadmin or enable custom Lua files
-	//setl lua_modules ""
+	setl lua_modules "lowercasemap.lua"
 
 	set g_log "legacy1.log"
 

--- a/configs/legacy3-snaps.config
+++ b/configs/legacy3-snaps.config
@@ -128,7 +128,7 @@ init
 	setl g_pronedelay "1"
 
 	// set this to disable wolfadmin or enable custom Lua files
-	//setl lua_modules ""
+	setl lua_modules "lowercasemap.lua"
 
 	set g_log "legacy3.log"
 

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -128,7 +128,7 @@ init
 	setl g_pronedelay "1"
 
 	// set this to disable wolfadmin or enable custom Lua files
-	//setl lua_modules ""
+	setl lua_modules "lowercasemap.lua"
 
 	set g_log "legacy3.log"
 

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -128,7 +128,7 @@ init
 	setl g_pronedelay "1"
 
 	// set this to disable wolfadmin or enable custom Lua files
-	//setl lua_modules ""
+	setl lua_modules "lowercasemap.lua"
 
 	set g_log "legacy6.log"
 

--- a/lowercasemap.lua
+++ b/lowercasemap.lua
@@ -1,0 +1,28 @@
+-- change mApNAmE to mapname if needed
+-- this is useful because server-side mapscripts are case-sensitive,
+--+and players have control over the case of mapname
+
+-- hazz
+-- Feb 2023
+
+local modname = "Lowercase mapname"
+local version = 1.0
+
+function getMap()
+	return et.trap_Cvar_Get("mapname")
+end
+
+function setMap(map)
+	et.trap_SendConsoleCommand(et.EXEC_APPEND, "map " .. map .. ";")
+end
+
+-- callbacks
+function et_InitGame(levelTime, randomSeed, restart)
+	et.RegisterModname(modname .. " " .. version .. " " .. et.FindSelf())
+
+	currentMap = getMap()
+	if currentMap ~= string.lower(currentMap) then
+		setMap(string.lower(currentMap))
+	end
+end
+


### PR DESCRIPTION
Force all map names to lowercase. Players can currently cause a mapscript not to load by voting e.g. `callvote map Te_escape2` instead of `te_escape2`. With this servers only ever need to keep one mapscript per map (in all lowercase, obviously).

Most importantly this fixes the problem with karsiah, where the BSP file is named `Karsiah_te2.bsp` so voting from menu gives a capital letter, while when voting from console players usually vote all lowercase.