### PR TITLE
fix some nonsolid brushes in erdenberg_t2

### DIFF
--- a/mapscripts/erdenberg_t2.script
+++ b/mapscripts/erdenberg_t2.script
@@ -3,6 +3,78 @@ game_manager
 	spawn
 	{
 
+		create {
+			classname "func_fakebrush"
+			origin "2880 -1343 -310"
+			mins "0 0 0"
+			maxs "144 32 24"
+			scriptname "nonsolidfix1"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2719 -440 -450"
+			mins "-31 -300 0"
+			maxs "0 0 195"
+			scriptname "nonsolidfix2"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2711 -440 -254"
+			mins "-16 -247 0"
+			maxs "0 0 6"
+			scriptname "nonsolidfix3"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2703 -687 -254"
+			mins "-8 -8 0"
+			maxs "8 8 64"
+			scriptname "nonsolidfix4"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2703 -440 -254"
+			mins "-8 -8 0"
+			maxs "8 8 64"
+			scriptname "nonsolidfix5"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2704 -1056 -416"
+			mins "-16 -16 0"
+			maxs "16 16 156"
+			scriptname "nonsolidfix6"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "2704 -743 -416"
+			mins "-16 -16 0"
+			maxs "16 16 156"
+			scriptname "nonsolidfix7"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "5768 -2208 -486"
+			mins "-8 -8 0"
+			maxs "8 8 130"
+			scriptname "nonsolidfix8"
+			contents "1"
+		}
+		create {
+			classname "func_fakebrush"
+			origin "5768 -2088 -486"
+			mins "-8 -8 0"
+			maxs "8 8 130"
+			scriptname "nonsolidfix9"
+			contents "1"
+		}
 		wait 30
 		wm_allied_respawntime 20
 		wm_axis_respawntime 30

--- a/mapscripts/erdenberg_t2.script
+++ b/mapscripts/erdenberg_t2.script
@@ -5,7 +5,7 @@ game_manager
 
 		create {
 			classname "func_fakebrush"
-			origin "2880 -1343 -310"
+			origin "2880 -1343 -312"
 			mins "0 0 0"
 			maxs "144 32 24"
 			scriptname "nonsolidfix1"


### PR DESCRIPTION
The map erdenberg_t2 has quite a few nonsolid brushes that can be abused. Some of them can be shot through, and some even walked through. This video shows most of them:

https://streamable.com/2k3f56

There are a couple of other smaller ones that are also fixed by this pull request.

Some of the fakebrushes have strange mins/maxs, because I needed to work around [#2242](https://github.com/etlegacy/etlegacy/issues/2242).

I deliberately didn't fix these 3 nonsolid brushes for 2 reasons: working around the above issue would be a little painful there (would require multiple fakebrushes) and more importantly, fixing them would make movement in the map more annoying.

![image](https://user-images.githubusercontent.com/107760898/221330034-22b56809-93f4-444e-80bd-cf011c009899.png)
![image](https://user-images.githubusercontent.com/107760898/221330057-fa860ad1-e4f8-48c5-8035-f0865df574dd.png)
