### PR TITLE
fix goldrush tank damaged-but-not-damaged bug

### DIFF
--- a/mapscripts/sw_goldrush_te.script
+++ b/mapscripts/sw_goldrush_te.script
@@ -1040,13 +1040,17 @@ tank
 		trigger self stuck_check
 		accum 1 abort_if_bitset 3 	// stuck check
 
+		// do death check before accum 4 set 0, because
+		//+otherwise tank_disabler doesn't have a chance to increase accum 4 to 4,
+		//+and tank will be stuck until Allies move away from it
+		//+(unable to move but can't be fixed either)
+		accum 1 abort_if_bitset 7 	// death check
+
 		accum 4 set 0				// reset stop counter
 		accum 1 bitreset 8			// reset stop check
 
 		accum 1 abort_if_bitset 2 	// already following spline
 		accum 5 abort_if_not_equal 0	// are we not in a script lockout?
-
-		accum 1 abort_if_bitset 7 	// death check
 
 		// Any just started moving stuff goes here
 


### PR DESCRIPTION
If Allies start moving tank just as its health drops to 0, the tank will be stuck - it won't be properly destroyed, but it can't be fixed either. In-game workaround is for Allies to move away from the tank until it's been properly damaged. (Some players think Axis need to nade it more, but that's just because when Axis nade it more, Allies will naturally move away from it... :D)

This PR puts the death check before the stop counter reset (rather than after, where it was), so the stop counter doesn't constantly get set back to 0 if the tank is dead, so the tank can be properly damaged any time its health is 0.

Video demonstrating the issue:

https://user-images.githubusercontent.com/107760898/223433505-38229837-4e85-4316-87e8-bba824c3b598.mp4

Note: this is a huge pain to test because the timing is so precise, so there's a chance this fix doesn't actually work. Would like to hear any reports of anyone managing to reproduce the bug on the video even with the mapscript fix.