### PR TITLE
add optional angle loading

### DIFF
--- a/saveload.lua
+++ b/saveload.lua
@@ -3,29 +3,43 @@
 -- restores position on /load
 -- resets speed to 0
 -- saves and loads amount of stamina
+-- loads angles (/load_noangles to only load position)
 
 -- hazz
--- Feb 2023
+-- May 2023
 
 local modname = "SaveLoad"
-local version = 1.0
+local version = 1.1
 local playerPositions = {}
+local playerAngles = {}
 local playerSprints = {}
+-- dummy teleporter, keep far away so people don't accidentally run into it
+local teleporterPosition = {60606, 60606, 60606}
 
 function savePosition(clientNum)
 	pos = et.gentity_get(clientNum, "ps.origin")
 	playerPositions[clientNum] = pos
 	sprint = et.gentity_get(clientNum, "ps.stats", et.STAT_SPRINTTIME)
 	playerSprints[clientNum] = sprint +.0
+	angles = et.gentity_get(clientNum, "ps.viewangles")
+	playerAngles[clientNum] = angles
 end
 
-function loadPosition(clientNum)
+function loadPosition(clientNum, withAngles)
 	if playerPositions[clientNum] == nil then
 		return
 	end
 
-	pos = playerPositions[clientNum]
-	et.gentity_set(clientNum, "ps.origin", playerPositions[clientNum])
+	-- using teleporter also when not loading angles,
+	--+because it prevents lerping (trigger_teleport is predicted)
+	et.G_SetSpawnVar(destNum, "origin", playerPositions[clientNum])
+	if withAngles then
+		et.G_SetSpawnVar(destNum, "angle", playerAngles[clientNum])
+	else
+		currentAngles = et.gentity_get(clientNum, "ps.viewangles")
+		et.G_SetSpawnVar(destNum, "angle", currentAngles)
+	end
+	et.gentity_set(clientNum, "ps.origin", teleporterPosition)
 
 	-- reset speed so you don't have to load more than once
 	et.gentity_set(clientNum, "ps.velocity", {0, 0, 0})
@@ -39,16 +53,27 @@ end
 
 -- callbacks
 function et_InitGame(levelTime, randomSeed, restart)
-	et.RegisterModname(modname .. version .. " " .. et.FindSelf())
+	et.RegisterModname(modname .. " " .. version .. " " .. et.FindSelf())
 end
 
 function et_ClientCommand(clientNum, command)
+	command = string.lower(command)
 	if command == "save" then
 		savePosition(clientNum)
 		return 1
 	end
 	if command == "load" then
-		loadPosition(clientNum)
+		loadPosition(clientNum, true)
+		return 1
+	end
+	if command == "load_noangles" then
+		loadPosition(clientNum, false)
 		return 1
 	end
 end
+
+function et_SpawnEntitiesFromString()
+	destNum = et.G_CreateEntity("scriptname \"load_dest\" origin \"1234 123 123\" angle \"123 123 123\" classname \"misc_teleporter_dest\" targetname \"saveload_dest\"")
+	et.G_CreateEntity("scriptname \"load_trig\" origin \""..table.concat(teleporterPosition, " ").."\" mins \"-8 -8 -32\" maxs \"8 8 32\" classname \"trigger_teleport\" target \"saveload_dest\"")
+end
+


### PR DESCRIPTION
This PR adds the ability for players to also load their angles. This is done with a `trigger_teleport` and a `misc_teleporter_dest`. The player is moved to the location of the former, and the `angle` and `origin` of the latter are changed when a player loads.

There are two advantages to this approach: players can `/load` their angles, and because `trigger_teleport` is predicted, players don't experience visible lerping through walls.

Players can use `/load_noangles` to load their position without loading the angles.

NOTE: Using entities like this is unavoidable, because `et.gentity_set(cno, "ps.viewangles", angles)` does not work.

NOTE: There will probably be some trouble if two players load on the same frame. It's probably not worth making the code more robust for that, because whichever players ends up in the wrong spot can simply load again.