### PR TITLE
Revert "Disable newly introduced cvar cg_impactEffects"

### DIFF
--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -141,7 +141,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3-snaps.config
+++ b/configs/legacy3-snaps.config
@@ -141,7 +141,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -141,7 +141,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy5.config
+++ b/configs/legacy5.config
@@ -141,7 +141,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -141,7 +141,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/practice.config
+++ b/configs/practice.config
@@ -136,7 +136,6 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"


### PR DESCRIPTION
Reverts ET-Legacy-Competitive/Legacy-Competition-League-Configs#35

The cvar was not behaving as expected and a fix was made with a new build.  The default setting `7` of the cvar now behaves as expected.  We can revert this change now.  

https://github.com/etlegacy/etlegacy/commit/30aa1b8e65baa28f75a682d787d9c3e809b178aa