### PR TITLE
Update cg_impactEffects bitmask after bug fix was released in v2.81.1-218

### DIFF
--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -141,6 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -141,7 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy1.config
+++ b/configs/legacy1.config
@@ -150,7 +150,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/configs/legacy3-snaps.config
+++ b/configs/legacy3-snaps.config
@@ -150,7 +150,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 100"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/configs/legacy3-snaps.config
+++ b/configs/legacy3-snaps.config
@@ -141,6 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3-snaps.config
+++ b/configs/legacy3-snaps.config
@@ -141,7 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -141,6 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -141,7 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -150,7 +150,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/configs/legacy5.config
+++ b/configs/legacy5.config
@@ -141,6 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy5.config
+++ b/configs/legacy5.config
@@ -141,7 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy5.config
+++ b/configs/legacy5.config
@@ -150,7 +150,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -141,6 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -141,7 +141,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -150,7 +150,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/configs/practice.config
+++ b/configs/practice.config
@@ -136,6 +136,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_impactEffects EQ 0"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/practice.config
+++ b/configs/practice.config
@@ -136,7 +136,7 @@ init
 
 	command "sv_cvar cg_simpleItems IN 0 1"
 	command "sv_cvar cg_visualEffects EQ 0"
-	command "sv_cvar cg_impactEffects EQ 0"
+	command "sv_cvar cg_impactEffects IN 0 7"
 	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"

--- a/configs/practice.config
+++ b/configs/practice.config
@@ -145,7 +145,7 @@ init
 	command "sv_cvar rate EQ 45000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 40"
-	command "sv_cvar com_maxfps IN 40 250"
+	command "sv_cvar com_maxfps IN 40 500"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/etl_server_comp.cfg
+++ b/etl_server_comp.cfg
@@ -7,13 +7,13 @@
 // CLIENTS
 
 set sv_maxclients 			  ""						      // number of players including private slots
-set sv_privateclients   	"0"                 // if set > 0, then this number of client slots will be reserved for connections 
-set sv_privatepassword  	""                  // that have "password" set to the value of "sv_privatePassword" 
+set sv_privateclients   	"0"                 // if set > 0, then this number of client slots will be reserved for connections
+set sv_privatepassword  	""                  // that have "password" set to the value of "sv_privatePassword"
 
 // PASSWORDS
 
-set g_password				    ""      			      // set to password the server 
-set rconpassword			    ""       			      // remote console access password 
+set g_password				    ""      			      // set to password the server
+set rconpassword			    ""       			      // remote console access password
 set refereePassword 		  ""    				      // referee status password
 set ShoutcastPassword		  ""						      // shoutcaster status password
 
@@ -32,29 +32,29 @@ set sv_hidden "1"
 
 // DOWNLOAD
 
-set sv_maxRate             "45000"            // 10000 standard but poor for ET 
-set sv_dl_maxRate 			   "42000"            // increase/decerease if you have plenty/little spare bandwidth 
-set sv_allowDownload 		   "1"                // global toggle for both legacy download and web download 
-set sv_wwwDownload 			   "1"                // toggle to enable web download 
-set sv_wwwBaseURL 			   ""        	        // base URL for redirection 
-set sv_wwwDlDisconnected	 "0"                // tell clients to perform their downloads while disconnected from the server 
-set sv_wwwFallbackURL 		 ""                 // URL to send to if an http/ftp fails or is refused client side 
+set sv_maxRate             "45000"            // 10000 standard but poor for ET
+set sv_dl_maxRate 			   "42000"            // increase/decerease if you have plenty/little spare bandwidth
+set sv_allowDownload 		   "1"                // global toggle for both legacy download and web download
+set sv_wwwDownload 			   "1"                // toggle to enable web download
+set sv_wwwBaseURL 			   ""        	        // base URL for redirection
+set sv_wwwDlDisconnected	 "0"                // tell clients to perform their downloads while disconnected from the server
+set sv_wwwFallbackURL 		 ""                 // URL to send to if an http/ftp fails or is refused client side
 
 // MOTD
 
-set sv_hostname  			     "" 
-set server_motd0 			     ""   
+set sv_hostname  			     ""
+set server_motd0 			     ""
 set server_motd1 			     ""
 set server_motd2 			     ""
 set server_motd3 			     ""
 set server_motd4 			     ""
 set server_motd5 			     ""
 
-// MISC SETTINGS 
+// MISC SETTINGS
 
 set sv_fps 					       "40"					      // to ensure that the server starts at sv_fps 40
 set g_customConfig 			   "legacy6"		      // sets the config that the server will load upon starting
-set g_gametype 				     "3"					      // game type should be set from map rotation script 
+set g_gametype 				     "3"					      // game type should be set from map rotation script
 
 // OMNIBOTS
 
@@ -72,12 +72,12 @@ set sv_protectLog 			   "sv_protect.log"		// when set all sv_protect and server 
 
 set sv_pure 				       "1"						    // enable hash check of client pk3 files
 set sv_protect 				     "1"						    // getstatus response limit protection
-set sv_guidCheck 			     "0"						    // invalid guid checking for players connecting to a server - "1" prevents 2.60b clients without PB from connecting
+set g_guidCheck 			     "0"						    // invalid guid checking for players connecting to a server - "1" prevents 2.60b clients without PB from connecting
 set g_protect 				     "1"						    // mod side security options
 
-// WATCHDOG - in case the game dies with an ERR_DROP or any situation leading to server running with no map 
+// WATCHDOG - in case the game dies with an ERR_DROP or any situation leading to server running with no map
 
-set com_watchdog 			     "60"            		// defaults to 60 
+set com_watchdog 			     "60"            		// defaults to 60
 set com_watchdog_cmd       "exec objectivecycle.cfg"  // defaults to quit
 
 // MAP


### PR DESCRIPTION
`cg_impactEffects` was causing red smoke or no feedback at all in the last build `v2.81.1-99`.  Now that the bug fix is in, the default bitmask of `7` acts as the expected / vanilla behavior.  This PR is to change the bitmask value from `0` to `7` to account for the bug fix and newly introduced cvar overall.  