### PR TITLE
Make supply truck more responsive after 1st stage

### DIFF
--- a/mapscripts/supply.script
+++ b/mapscripts/supply.script
@@ -169,6 +169,7 @@ forwardgate {
                 trigger forwardflag force_allied        //Switch forward spawn permanently to allies
                 trigger forwardflag kill                //Remove flag
                 trigger truck enable_stage1                //Let truck through
+                trigger truck forwardgate_blown                //Let the truck be more responsive in the 2nd stage
 
                 wm_announce "The Allies have breached the Forward Bunker Gate!"
                 wm_objective_status         1 0 2
@@ -1907,6 +1908,18 @@ truck {
                 trigger truckfrontwheels stop
                 trigger truckbackwheels stop
 
+                // We're in first stage, so
+                // truck should still have the original behaviour to avoid
+                // moving the truck too close to the forward gate
+                accum 6 trigger_if_equal 0 truck stopcheck_longwait
+
+                // 2nd stage and later, truck can be more responsive without as much risk of
+                // moving the truck too far by accident
+                accum 6 trigger_if_equal 1 truck stopcheck_shortwait
+
+        }
+
+        trigger stopcheck_longwait {
                 wait 800
 
                 playsound sound/vehicles/truck/truck_idle.wav looping
@@ -1915,6 +1928,21 @@ truck {
 
                 trigger self script_lockout_stop
                 resetscript
+        }
+
+        trigger stopcheck_shortwait {
+                wait 15
+
+                playsound sound/vehicles/truck/truck_idle.wav looping
+
+                wait 15
+
+                trigger self script_lockout_stop
+                resetscript
+        }
+
+        trigger forwardgate_blown {
+                accum 6 set 1
         }
 
         trigger script_lockout {


### PR DESCRIPTION
The truck on supply originally waits a total of 1.7sec every time it stops before it can start moving again. This PR reduces that wait to 30ms, making the truck feel a lot more responsive, quite similar to the truck on Goldrush (although still not quite as responsive, as the truck on Goldrush also has no delay when starting to move the truck.)

Note that it doesn't make the truck move any faster, but it does make attacking slightly easier in general, because there will be less of the "wtf why doesn't the truck move" moments. I think that's justified, considering how hard supply is to attack.

The change only takes effect after the first gate has been destroyed, because it's already annoying enough to keep the truck from moving too far in the 1st stage.