### PR TITLE
Fix tank sound sometimes playing when tank damaged

### DIFF
--- a/mapscripts/sw_goldrush_te.script
+++ b/mapscripts/sw_goldrush_te.script
@@ -253,6 +253,10 @@ tank
 
 	trigger sound_move
 	{
+		// check to see if tank is dead before looping the move sound
+		// needed because sound_move gets called after a wait in trigger tank_sound start,
+		//+and tank might have died in the meantime
+		accum 1 abort_if_bitset 7
 		stopsound
 		playsound sound/vehicles/tank/tank_move.wav looping volume 512
 	}


### PR DESCRIPTION
Fixes the bug where the "tank moving" sound keeps looping if the tank is damaged right after it started moving.